### PR TITLE
Added config param for setting system path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,7 @@
         "jdk.compiler/com.sun.tools.javac.model",
         "jdk.compiler/com.sun.tools.javac.util",
     ],
+    "java.setSystemPath": false
     // "typescript.tsserver.trace": "verbose",
     // "java.trace.server": "verbose",
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1688177999,
+        "narHash": "sha256-JZ5nk90Ym79b4J593xYb0mI79QxU0efJLuCU3sXDalQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0de86059128947b2438995450f2c2ca08cc783d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,10 @@
   outputs = { self, nixpkgs, ... }:
     let
       pkgs = import nixpkgs { system = "x86_64-linux"; };
+      package = pkgs.callPackage ./java-language-server.nix {
+        lib = pkgs.lib;
+        jdk = pkgs.graalvm19-ce;
+      };
     in
     
     {
@@ -14,9 +18,11 @@
         ];
       };
 
-      packages.x86_64-linux.default = pkgs.callPackage ./java-language-server.nix {
-        lib = pkgs.lib;
-        jdk = pkgs.graalvm19-ce;
-      }; 
+      packages.x86_64-linux.default = package;
+
+      overlays.default = final: prev: {
+        java-language-server = package;
+      };
+      
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Language Server for Java using the Java compiler API";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      pkgs = import nixpkgs { system = "x86_64-linux"; };
+    in
+    
+    {
+      devShells.x86_64-linux.default = pkgs.mkShell {
+        packages = [
+          pkgs.graalvm19-ce
+        ];
+      };
+
+      packages.x86_64-linux.default = pkgs.callPackage ./java-language-server.nix {
+        lib = pkgs.lib;
+        jdk = pkgs.graalvm19-ce;
+      }; 
+    };
+}

--- a/java-language-server.nix
+++ b/java-language-server.nix
@@ -1,0 +1,95 @@
+# This was modified from https://github.com/NixOS/nixpkgs/blob/nixos-23.05/pkgs/development/tools/java/java-language-server/default.nix
+{ lib
+, stdenv
+, fetchFromGitHub
+, jdk
+, maven
+, runtimeShell
+, makeWrapper
+}:
+
+let
+  platform =
+    if stdenv.isLinux then "linux"
+    else if stdenv.isDarwin then "mac"
+    else if stdenv.isWindows then "windows"
+    else throw "unsupported platform";
+in
+stdenv.mkDerivation rec {
+  pname = "java-language-server";
+  version = "0.2.38";
+
+  src = ./.;
+
+  fetchedMavenDeps = stdenv.mkDerivation {
+    name = "java-language-server-${version}-maven-deps";
+    inherit src;
+    buildInputs = [ maven ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      mvn package -Dmaven.repo.local=$out -DskipTests -e
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      find $out -type f \
+        -name \*.lastUpdated -or \
+        -name resolver-status.properties -or \
+        -name _remote.repositories \
+        -delete
+
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+    dontConfigure = true;
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-YqYXtFeDByhqkPytkRakj85pkoi5UKD9/SkSqSJ1XBA=";
+  };
+
+
+  nativeBuildInputs = [ maven jdk makeWrapper ];
+
+  dontConfigure = true;
+  buildPhase = ''
+    runHook preBuild
+
+    jlink \
+      ${lib.optionalString (!stdenv.isDarwin) "--module-path './jdks/${platform}/jdk-13/jmods'"} \
+      --add-modules java.base,java.compiler,java.logging,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
+      --output dist/${platform} \
+      --no-header-files \
+      --no-man-pages \
+      --compress 2
+
+    mvn package --offline -Dmaven.repo.local=${fetchedMavenDeps} -DskipTests
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/java/java-language-server
+    cp -r dist/classpath dist/*${platform}* $out/share/java/java-language-server
+
+    # a link is not used as lang_server_${platform}.sh makes use of "dirname $0" to access other files
+    makeWrapper $out/share/java/java-language-server/lang_server_${platform}.sh $out/bin/java-language-server
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A Java language server based on v3.0 of the protocol and implemented using the Java compiler API";
+    homepage = "https://github.com/replit/java-language-server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hqurve ];
+    platforms = platforms.all;
+  };
+}

--- a/package.json
+++ b/package.json
@@ -119,6 +119,10 @@
                     ],
                     "default": "off",
                     "description": "Traces the communication between VSCode and the language server."
+                },
+                "java.setSystemPath": {
+                    "type": "boolean",
+                    "description": "Option to pass the Java home directory to the --system flag for the javac command for inferences"
                 }
             }
         },

--- a/src/main/java/org/javacs/CompileBatch.java
+++ b/src/main/java/org/javacs/CompileBatch.java
@@ -101,7 +101,7 @@ class CompileBatch implements AutoCloseable {
     private static ReusableCompiler.Borrow batchTask(
             JavaCompilerService parent, Collection<? extends JavaFileObject> sources) {
         parent.diags.clear();
-        var options = options(parent.classPath, parent.addExports);
+        var options = options(parent.javaHome, parent.setSystemPath, parent.classPath, parent.addExports);
         return parent.compiler.getTask(parent.fileManager, parent.diags::add, options, List.of(), sources);
     }
 
@@ -110,7 +110,7 @@ class CompileBatch implements AutoCloseable {
         return classOrSourcePath.stream().map(Path::toString).collect(Collectors.joining(File.pathSeparator));
     }
 
-    private static List<String> options(Set<Path> classPath, Set<String> addExports) {
+    private static List<String> options(Path javaHome, boolean setSystemPath, Set<Path> classPath, Set<String> addExports) {
         var list = new ArrayList<String>();
 
         Collections.addAll(list, "-classpath", joinPath(classPath));
@@ -134,6 +134,13 @@ class CompileBatch implements AutoCloseable {
         for (var export : addExports) {
             list.add("--add-exports");
             list.add(export + "=ALL-UNNAMED");
+        }
+        if (setSystemPath) {
+            if (javaHome == null) {
+                javaHome = JavaHomeHelper.javaHome();
+            }
+            list.add("--system");
+            list.add(javaHome.toString());
         }
 
         return list;

--- a/src/main/java/org/javacs/JavaCompilerService.java
+++ b/src/main/java/org/javacs/JavaCompilerService.java
@@ -10,6 +10,8 @@ import javax.tools.*;
 
 class JavaCompilerService implements CompilerProvider {
     // Not modifiable! If you want to edit these, you need to create a new instance
+    final Path javaHome;
+    final boolean setSystemPath;
     final Set<Path> classPath, docPath;
     final Set<String> addExports;
     final ReusableCompiler compiler = new ReusableCompiler();
@@ -21,7 +23,9 @@ class JavaCompilerService implements CompilerProvider {
     // TODO intercept files that aren't in the batch and erase method bodies so compilation is faster
     final SourceFileManager fileManager;
 
-    JavaCompilerService(Set<Path> classPath, Set<Path> docPath, Set<String> addExports) {
+    JavaCompilerService(Path javaHome, boolean setSystemPath, Set<Path> classPath, Set<Path> docPath, Set<String> addExports) {
+        this.javaHome = javaHome;
+        this.setSystemPath = setSystemPath;
         System.err.println("Class path:");
         for (var p : classPath) {
             System.err.println("  " + p);

--- a/src/main/java/org/javacs/JavaLanguageServer.java
+++ b/src/main/java/org/javacs/JavaLanguageServer.java
@@ -96,7 +96,7 @@ class JavaLanguageServer extends LanguageServer {
         // If classpath is specified by the user, don't infer anything
         if (!classPath.isEmpty()) {
             javaEndProgress();
-            return new JavaCompilerService(classPath, docPath(), addExports);
+            return new JavaCompilerService(home(), setSystemPath(), classPath, docPath(), addExports);
         }
         // Otherwise, combine inference with user-specified external dependencies
         else {
@@ -109,7 +109,7 @@ class JavaLanguageServer extends LanguageServer {
             var docPath = infer.buildDocPath();
 
             javaEndProgress();
-            return new JavaCompilerService(classPath, docPath, addExports);
+            return new JavaCompilerService(home(), setSystemPath(), classPath, docPath, addExports);
         }
     }
 
@@ -150,6 +150,24 @@ class JavaLanguageServer extends LanguageServer {
             strings.add(each.getAsString());
         }
         return strings;
+    }
+
+    private Path home() {
+        if (!settings.has("home")) return null;
+        var home = settings.get("home");
+        if (home == null) return null;
+        var homeStr = home.getAsString().trim();
+        if (homeStr.isEmpty()) {
+            return null;
+        }
+        return Paths.get(homeStr);
+    }
+
+    private boolean setSystemPath() {
+        if (!settings.has("setSystemPath")) return false;
+        var value = settings.get("setSystemPath");
+        if (value == null) return false;
+        return value.getAsBoolean();
     }
 
     @Override

--- a/src/main/java/org/javacs/Main.java
+++ b/src/main/java/org/javacs/Main.java
@@ -1,6 +1,7 @@
 package org.javacs;
 
 import java.util.Arrays;
+import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.javacs.lsp.*;
@@ -16,6 +17,16 @@ public class Main {
         }
     }
 
+    private static void handleLogFileArg(String[] args) throws java.io.IOException {
+        for (int i = 0; i < args.length; i++) {
+            if (args[i].equals("--logFile") && i + 1 < args.length) {
+                String logFile = args[i + 1];
+                Logger.getLogger("").addHandler(new FileHandler(logFile, false));
+            }
+            
+        }
+    }
+
     public static void main(String[] args) {
         boolean quiet = Arrays.stream(args).anyMatch("--quiet"::equals);
 
@@ -24,7 +35,7 @@ public class Main {
         }
 
         try {
-            // Logger.getLogger("").addHandler(new FileHandler("javacs.%u.log", false));
+            handleLogFileArg(args);
             setRootFormat();
 
             LSP.connect(JavaLanguageServer::new, System.in, System.out);

--- a/src/test/java/org/javacs/BenchmarkPruner.java
+++ b/src/test/java/org/javacs/BenchmarkPruner.java
@@ -38,7 +38,7 @@ public class BenchmarkPruner {
             var workspaceRoot = Paths.get(".").normalize().toAbsolutePath();
             FileStore.setWorkspaceRoots(Set.of(workspaceRoot));
             var classPath = new InferConfig(workspaceRoot).classPath();
-            return new JavaCompilerService(classPath, Collections.emptySet(), Collections.emptySet());
+            return new JavaCompilerService(null, false, classPath, Collections.emptySet(), Collections.emptySet());
         }
     }
 

--- a/src/test/java/org/javacs/JavaCompilerServiceTest.java
+++ b/src/test/java/org/javacs/JavaCompilerServiceTest.java
@@ -13,7 +13,7 @@ public class JavaCompilerServiceTest {
     }
 
     private JavaCompilerService compiler =
-            new JavaCompilerService(Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
+            new JavaCompilerService(null, false, Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
 
     static Path simpleProjectSrc() {
         return Paths.get("src/test/examples/simple-project").normalize();


### PR DESCRIPTION
# Why?

This is a solution to https://github.com/georgewfraser/java-language-server/issues/124 by allowing the client to provide configuration parameters that cause the setting of the `--system` flag for javac.
Also for ease of diagnose added a `--logFile` parameter to cli command

## Changes

1. Added workspace configuration parameters:
    * `java.setSystemPath` - a boolean for whether to set the `--system` flag. If this is true and `java.home` is not provided, it will try to automatically resolve it based on the `JAVAHOME` env var or normal installation location based on the OS
2. if `java.setSystemPath` is set to true, it will add a `--system <java home>` arg to the javac command when compiling a file for info. More info https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html
3. added `--logFile` parameter
4. Added flake.nix for dev, build, and overlay

## Testing

1. clone the repo
2. `git checkout th-set-system-path`
3. `nix develop`
5. `scripts/link_linux.sh` (or `scripts/link_mac.sh` if you use mac)
6. `mvn package -DskipTests`
7. In `.vscode/settings.json`, temporarily change the `java.setSystemPath` default setting from false to true
8. `npm i`
9. `npm run-script vscode:build`, this creates `build.vsix` in the project directory
10. Open VS code, go to extensions
11. remove "Java Language Server" if it's already installed, reload VS Code and go to extensions again
12. click the triple dot and select "Install from VSIX...", choose the `build.vsix` that was built
13. Make a file `Main.java` based on https://gist.github.com/airportyh/b97570b1c46d839678ebd14e6e8e690d
14. JFrame should not have red squigglies under it. Hover over `JFrame` you should get help info about it.

![Screenshot from 2023-07-03 11-15-56](https://github.com/replit/java-language-server/assets/54303/0cb4be3d-987d-4e47-b91e-561f1e318759)

